### PR TITLE
Adding contributing guidelines document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to Student Toolbox
+
+We want to make contributing to this project as easy and transparent as possible.
+
+## Contents of this guideline
+
+- [When contributing](#we-use-github-flow-so-all-code-changes-happen-through-pull-requests)
+- [Proposing new features](#propose-new-features-using-githubs-issues)
+- [Reporting a bug](#report-bugs-using-githubs-issues)
+- [License](#license)
+
+## We Use Github Flow, So All Code Changes Happen Through Pull Requests when contributing
+
+Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests:
+
+1. Fork the repo and create your branch from `master`.
+2. When creating a pull request, please use our pull request template.
+3. If you've added code that should be tested, add tests.
+4. Ensure the test suite passes if any.
+5. Make sure your code lints.
+6. Issue that pull request!
+7. Once the issue has been reviewed and approved, it should be squashed and merged.
+
+## Propose new features using Github's [issues](https://github.com/Snacc-Overflow/student-toolbox/issues)
+
+We use GitHub issues to track proposed features. Propose a feature by [opening a new issue](https://github.com/Snacc-Overflow/student-toolbox/issues/new/choose); and choosing the Feature Request template, it's that easy!
+
+## Report bugs using Github's [issues](https://github.com/Snacc-Overflow/student-toolbox/issues)
+
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/Snacc-Overflow/student-toolbox/issues/new/choose); and choosing the Bugs template, it's that easy!
+
+## License
+
+By contributing, you agree that your contributions will be licensed under its MIT License.
+
+## Any contributions you make will be under the MIT Software License
+
+In short, when you submit code changes, your submissions are understood to be under the same [MIT License](https://github.com/Snacc-Overflow/student-toolbox/blob/main/LICENSE) that covers the project. Feel free to contact the maintainers if that's a concern.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,38 +1,49 @@
-# Contributing to Student Toolbox
+# 🎒 Contributing to Student Toolbox
 
 We want to make contributing to this project as easy and transparent as possible.
 
-## Contents of this guideline
+## 📚 Contents of this Guideline
 
-- [When contributing](#we-use-github-flow-so-all-code-changes-happen-through-pull-requests)
-- [Proposing new features](#propose-new-features-using-githubs-issues)
-- [Reporting a bug](#report-bugs-using-githubs-issues)
-- [License](#license)
+- [💻 When contributing](#we-use-github-flow-so-all-code-changes-happen-through-pull-requests)
+- [🌲 When creating branches and commits](#-branching-and-committing)
+- [✨ Proposing new features](#propose-new-features-using-githubs-issues)
+- [🐛 Reporting a bug](#report-bugs-using-githubs-issues)
+- [📜 License](#license)
 
-## We Use Github Flow, So All Code Changes Happen Through Pull Requests when contributing
+## 💻 We Use GitHub Flow, So All Code Changes Happen Through Pull Requests When Contributing
 
 Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests:
 
-1. Fork the repo and create your branch from `master`.
-2. When creating a pull request, please use our pull request template.
-3. If you've added code that should be tested, add tests.
-4. Ensure the test suite passes if any.
-5. Make sure your code lints.
-6. Issue that pull request!
-7. Once the issue has been reviewed and approved, it should be squashed and merged.
+1. 🍴 Fork the repo and create your branch from `main`.
+2. 📝 When creating a pull request, please use our pull request template.
+3. ✅ If you've added code that should be tested, add tests.
+4. 🚦 Ensure the test suite passes if any.
+5. 🔍 Make sure your code lints.
+6. 📤 Issue that pull request!
+7. 🛠️ Once the issue has been reviewed and approved, it should be squashed and merged.
 
-## Propose new features using Github's [issues](https://github.com/Snacc-Overflow/student-toolbox/issues)
+## 🌲 Branching and committing
 
-We use GitHub issues to track proposed features. Propose a feature by [opening a new issue](https://github.com/Snacc-Overflow/student-toolbox/issues/new/choose); and choosing the Feature Request template, it's that easy!
+Please follow these guidelines when creating branches:
 
-## Report bugs using Github's [issues](https://github.com/Snacc-Overflow/student-toolbox/issues)
+- Tag your branch with a valid branch type followed by a forward slash. Describe it using snake case. e.g., `feature/add_login_page` or `documentation/fix_comments`.
 
-We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/Snacc-Overflow/student-toolbox/issues/new/choose); and choosing the Bugs template, it's that easy!
+Please follow these guidelines when creating commits:
 
-## License
+- Tag your branch with a valid [commit type](#https://github.com/pvdlg/conventional-commit-types) followed by a colon. Describe it using snake case and a captital at the start. e.g., `feat: Add_login_page` or `docs: Fix_comments`.
+
+## ✨ Propose New Features Using GitHub's [Issues](https://github.com/Snacc-Overflow/student-toolbox/issues)
+
+We use GitHub issues to track proposed features. Propose a feature by [opening a new issue](https://github.com/Snacc-Overflow/student-toolbox/issues/new/choose) and choosing the Feature Request template—it's that easy!
+
+## 🐛 Report Bugs Using GitHub's [Issues](https://github.com/Snacc-Overflow/student-toolbox/issues)
+
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/Snacc-Overflow/student-toolbox/issues/new/choose) and choosing the Bugs template—it's that easy!
+
+## 📜 License
 
 By contributing, you agree that your contributions will be licensed under its MIT License.
 
-## Any contributions you make will be under the MIT Software License
+## 📄 Any Contributions You Make Will Be Under the MIT Software License
 
 In short, when you submit code changes, your submissions are understood to be under the same [MIT License](https://github.com/Snacc-Overflow/student-toolbox/blob/main/LICENSE) that covers the project. Feel free to contact the maintainers if that's a concern.


### PR DESCRIPTION
# Adding contributing guidelines document

## Related Issue
Closes #8 

## Description
- Contributor guidelines document that describes requirements for contributing to the Student Toolbox repository.

## Testing
N/A

## Images 
Top section of guidelines document
![image](https://github.com/user-attachments/assets/8196a086-ba08-4bf4-b7b7-b8ac3905f954)

## Additional Context
- This document will be updated as necessary.