### PR TITLE
Updated styling and customisability of calendar events.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^18",
         "react-blockies": "^1.4.1",
         "react-dom": "^18",
+        "react-modal": "^3.16.1",
         "sass": "^1.77.8"
       },
       "devDependencies": {
@@ -2073,6 +2074,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4043,6 +4050,31 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-modal": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
+      "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
+      "license": "MIT",
+      "dependencies": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -4913,6 +4945,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^18",
     "react-blockies": "^1.4.1",
     "react-dom": "^18",
+    "react-modal": "^3.16.1",
     "sass": "^1.77.8"
   },
   "devDependencies": {

--- a/src/app/timetable/components/calender/calender.js
+++ b/src/app/timetable/components/calender/calender.js
@@ -1,44 +1,49 @@
-"use client";
+"use client"; // Directive to indicate that this file should be treated as a client component in a Next.js application.
 
 import React, { useState, useEffect } from "react";
 import FullCalendar from "@fullcalendar/react";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import interactionPlugin from "@fullcalendar/interaction";
-import styles from "./style.module.scss";
-import EventModal from "./eventModal";
-import DeleteModal from "./deleteModal"; // New component for delete confirmation
+import styles from "./style.module.scss"; // Importing custom styles.
+import EventModal from "./eventModal"; // Component for creating new events.
+import DeleteModal from "./deleteModal"; // Component for confirming event deletion.
 
 export default function Calendar() {
-  const [modalIsOpen, setModalIsOpen] = useState(false);
-  const [deleteModalIsOpen, setDeleteModalIsOpen] = useState(false);
-  const [events, setEvents] = useState([]);
-  const [selectedInfo, setSelectedInfo] = useState(null);
-  const [selectedEvent, setSelectedEvent] = useState(null); // For delete confirmation
+  // State variables to manage modal visibility, events, and selected event info.
+  const [modalIsOpen, setModalIsOpen] = useState(false); // State to control the visibility of the event creation modal.
+  const [deleteModalIsOpen, setDeleteModalIsOpen] = useState(false); // State to control the visibility of the delete confirmation modal.
+  const [events, setEvents] = useState([]); // State to store the list of calendar events.
+  const [selectedInfo, setSelectedInfo] = useState(null); // State to store the information about the date selected for event creation.
+  const [selectedEvent, setSelectedEvent] = useState(null); // State to store the currently selected event for deletion.
 
-  // Fetch events from API
+  // Effect hook to fetch events from an API when the component is first rendered.
   useEffect(() => {
-    // Replace with your API call to fetch events
-    // setEvents();
-  }, []);
+    // Placeholder for API call to fetch events. Replace with actual API call.
+    // setEvents(); // This would be where you update the events state with data from your API.
+  }, []); // Empty dependency array ensures this runs only once on component mount.
 
+  // Function to handle date selection, triggering the event creation modal.
   const handleDateSelect = (selectInfo) => {
-    setSelectedInfo(selectInfo);
-    setModalIsOpen(true);
+    setSelectedInfo(selectInfo); // Store the selected date/time information.
+    setModalIsOpen(true); // Open the event creation modal.
   };
 
+  // Function to handle event click, triggering the delete confirmation modal.
   const handleEventClick = (clickInfo) => {
-    setSelectedEvent(clickInfo.event);
-    setDeleteModalIsOpen(true);
+    setSelectedEvent(clickInfo.event); // Store the event data that was clicked.
+    setDeleteModalIsOpen(true); // Open the delete confirmation modal.
   };
 
+  // Function to handle the deletion of an event.
   const handleEventDeletion = () => {
     if (selectedEvent) {
-      // Remove event from local state
+      // If an event is selected, filter it out of the events state.
       setEvents((prevEvents) =>
         prevEvents.filter((event) => event.id !== selectedEvent.id)
       );
-      // Close delete modal
+      // Close the delete confirmation modal.
       setDeleteModalIsOpen(false);
+      // Reset the selected event state to null.
       setSelectedEvent(null);
     }
   };
@@ -46,16 +51,17 @@ export default function Calendar() {
   return (
     <div className={styles.calendar_main}>
       <FullCalendar
-        plugins={[timeGridPlugin, interactionPlugin]}
-        initialView="timeGridWeek"
-        editable={true}
-        selectable={true}
-        events={events}
-        select={handleDateSelect}
-        eventClick={handleEventClick}
-        slotLaneClassNames="custom-slot-class"
+        plugins={[timeGridPlugin, interactionPlugin]} // Loading plugins for the calendar (e.g., time grid view, interaction).
+        initialView="timeGridWeek" // Setting the default view to a weekly time grid.
+        editable={true} // Allowing events to be draggable and resizable.
+        selectable={true} // Allowing date ranges to be selectable.
+        events={events} // Passing the list of events to the calendar.
+        select={handleDateSelect} // Event handler for date selection.
+        eventClick={handleEventClick} // Event handler for event clicks.
+        slotLaneClassNames="custom-slot-class" // Adding a custom class for further styling.
       />
 
+      {/* Render the event creation modal if it is open */}
       {modalIsOpen && (
         <EventModal
           isOpen={modalIsOpen}
@@ -65,6 +71,7 @@ export default function Calendar() {
         />
       )}
 
+      {/* Render the delete confirmation modal if it is open */}
       {deleteModalIsOpen && (
         <DeleteModal
           isOpen={deleteModalIsOpen}

--- a/src/app/timetable/components/calender/calender.js
+++ b/src/app/timetable/components/calender/calender.js
@@ -11,6 +11,8 @@ export default function Calendar() {
   // State to manage the visibility of the modal
   const [modalIsOpen, setModalIsOpen] = useState(false);
 
+  const [deleteModalIsOpen, setDeleteModalIsOpen] = useState(false);
+
   // State to store the selected date/time information when creating a new event
   const [selectedInfo, setSelectedInfo] = useState(null);
 
@@ -19,6 +21,8 @@ export default function Calendar() {
 
   // State to store the color selected by the user, with a default value
   const [color, setColor] = useState("#3788d8");
+
+  const [eventToDelete, setEventToDelete] = useState(null); // Track the event to be deleted
 
   // This function is triggered when a date/time range is selected in the calendar
   function handleDateSelect(selectInfo) {
@@ -51,12 +55,15 @@ export default function Calendar() {
 
   // This function is called when an event is clicked in the calendar
   function handleEventClick(clickInfo) {
-    if (
-      confirm(
-        `Are you sure you want to delete the event '${clickInfo.event.title}'`
-      )
-    ) {
-      clickInfo.event.remove(); // Remove the event if the user confirms
+    setEventToDelete(clickInfo.event); // Store the event to be deleted
+    setDeleteModalIsOpen(true); // Open the deletion confirmation modal
+  }
+
+  function handleEventDelete() {
+    if (eventToDelete) {
+      eventToDelete.remove(); // Remove the event if confirmed
+      setDeleteModalIsOpen(false); // Close the deletion modal
+      setEventToDelete(null); // Clear the event to delete state
     }
   }
 
@@ -107,6 +114,21 @@ export default function Calendar() {
             <button onClick={handleEventCreation}>Create Event</button>
             {/* Button to cancel and close the modal */}
             <button onClick={() => setModalIsOpen(false)}>Cancel</button>
+          </div>
+        </div>
+      )}
+
+      {/* Deletion Modal */}
+      {deleteModalIsOpen && (
+        <div className={styles.modalOverlay}>
+          <div className={styles.modalContent}>
+            <h2>Delete Event</h2>
+            <p>
+              Are you sure you want to delete the event '{eventToDelete?.title}
+              '?
+            </p>
+            <button onClick={handleEventDelete}>Yes, Delete</button>
+            <button onClick={() => setDeleteModalIsOpen(false)}>Cancel</button>
           </div>
         </div>
       )}

--- a/src/app/timetable/components/calender/calender.js
+++ b/src/app/timetable/components/calender/calender.js
@@ -4,88 +4,107 @@ import React, { useState } from "react";
 import FullCalendar from "@fullcalendar/react";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import interactionPlugin from "@fullcalendar/interaction";
-import { createEventId } from "./event-utils";
-import styles from "./style.module.scss";
+import { createEventId } from "./event-utils"; // Utility function to create unique event IDs
+import styles from "./style.module.scss"; // Importing custom styles
 
 export default function Calendar() {
+  // State to manage the visibility of the modal
   const [modalIsOpen, setModalIsOpen] = useState(false);
-  const [selectedInfo, setSelectedInfo] = useState(null);
-  const [title, setTitle] = useState("");
-  const [color, setColor] = useState("#3788d8"); // Default color
 
+  // State to store the selected date/time information when creating a new event
+  const [selectedInfo, setSelectedInfo] = useState(null);
+
+  // State to store the event title input by the user
+  const [title, setTitle] = useState("");
+
+  // State to store the color selected by the user, with a default value
+  const [color, setColor] = useState("#3788d8");
+
+  // This function is triggered when a date/time range is selected in the calendar
   function handleDateSelect(selectInfo) {
-    setSelectedInfo(selectInfo);
-    setModalIsOpen(true);
+    setSelectedInfo(selectInfo); // Save the selected date/time info
+    setModalIsOpen(true); // Open the modal for the user to enter event details
   }
 
+  // This function is called when the user confirms the creation of a new event
   function handleEventCreation() {
     if (title && selectedInfo) {
-      let calendarApi = selectedInfo.view.calendar;
+      // Ensure that the title and date info are provided
+      let calendarApi = selectedInfo.view.calendar; // Access the calendar API
 
+      // Add the new event to the calendar with the provided title and color
       calendarApi.addEvent({
-        id: createEventId(),
+        id: createEventId(), // Generate a unique ID for the event
         title,
-        start: selectedInfo.startStr,
-        end: selectedInfo.endStr,
-        allDay: selectedInfo.allDay,
-        backgroundColor: color,
-        borderColor: color,
+        start: selectedInfo.startStr, // Start time of the event
+        end: selectedInfo.endStr, // End time of the event
+        allDay: selectedInfo.allDay, // Whether the event is an all-day event
+        backgroundColor: color, // Background color for the event
+        borderColor: color, // Border color for the event
       });
 
-      setModalIsOpen(false);
-      setTitle("");
-      setColor("#3788d8"); // Reset to default
+      setModalIsOpen(false); // Close the modal
+      setTitle(""); // Reset the title input
+      setColor("#3788d8"); // Reset the color to the default value
     }
   }
 
+  // This function is called when an event is clicked in the calendar
   function handleEventClick(clickInfo) {
     if (
       confirm(
         `Are you sure you want to delete the event '${clickInfo.event.title}'`
       )
     ) {
-      clickInfo.event.remove();
+      clickInfo.event.remove(); // Remove the event if the user confirms
     }
   }
 
+  // This function defines how the event content is rendered on the calendar
   function renderEventContent(eventInfo) {
     return (
       <>
-        <b>{eventInfo.timeText}</b>
-        <i>{eventInfo.event.title}</i>
+        <b>{eventInfo.timeText}</b> {/* Display the event time */}
+        <i>{eventInfo.event.title}</i> {/* Display the event title */}
       </>
     );
   }
 
   return (
     <div className={styles.calendar_main}>
+      {/* FullCalendar component with various props */}
       <FullCalendar
-        plugins={[timeGridPlugin, interactionPlugin]}
-        initialView="timeGridWeek"
-        editable={true}
-        selectable={true}
-        height={650}
-        select={handleDateSelect}
-        eventContent={renderEventContent}
-        eventClick={handleEventClick}
+        plugins={[timeGridPlugin, interactionPlugin]} // Plugins for time grid view and interaction
+        initialView="timeGridWeek" // Default view is weekly time grid
+        editable={true} // Events can be edited (dragged, resized, etc.)
+        selectable={true} // Dates can be selected to create new events
+        height={650} // Height of the calendar
+        select={handleDateSelect} // Handle date selection
+        eventContent={renderEventContent} // Custom rendering of event content
+        eventClick={handleEventClick} // Handle event click
       />
 
+      {/* Modal for creating a new event, displayed only when modalIsOpen is true */}
       {modalIsOpen && (
         <div className={styles.modalOverlay}>
           <div className={styles.modalContent}>
             <h2>Create New Event</h2>
+            {/* Input for event title */}
             <input
               type="text"
               placeholder="Event Title"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
             />
+            {/* Input for event color */}
             <input
               type="color"
               value={color}
               onChange={(e) => setColor(e.target.value)}
             />
+            {/* Button to create the event */}
             <button onClick={handleEventCreation}>Create Event</button>
+            {/* Button to cancel and close the modal */}
             <button onClick={() => setModalIsOpen(false)}>Cancel</button>
           </div>
         </div>

--- a/src/app/timetable/components/calender/calender.js
+++ b/src/app/timetable/components/calender/calender.js
@@ -4,23 +4,27 @@ import FullCalendar from "@fullcalendar/react";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import { createEventId } from "./event-utils";
+import styles from "./style.module.scss";
 
 export default function Calendar() {
   return (
-    <FullCalendar
-      plugins={[timeGridPlugin, interactionPlugin]}
-      initialView="timeGridWeek"
-      editable={true}
-      selectable={true}
-      height={650}
-      select={handleDateSelect}
-      eventContent={renderEventContent}
-      eventClick={handleEventClick}
-    />
+    <div className={styles.calender_main}>
+      <FullCalendar
+        plugins={[timeGridPlugin, interactionPlugin]}
+        initialView="timeGridWeek"
+        editable={true}
+        selectable={true}
+        height={650}
+        select={handleDateSelect}
+        eventContent={renderEventContent}
+        eventClick={handleEventClick}
+      />
+    </div>
   );
 
   function handleDateSelect(selectInfo) {
     let title = prompt("Please enter a new title for your event");
+    let color = prompt("Please enter a color for your event (e.g., #ff0000)");
     let calendarApi = selectInfo.view.calendar;
 
     calendarApi.unselect(); // clear date selection
@@ -32,6 +36,8 @@ export default function Calendar() {
         start: selectInfo.startStr,
         end: selectInfo.endStr,
         allDay: selectInfo.allDay,
+        backgroundColor: color || "#3788d8", // Default color if none is provided
+        borderColor: color || "#3788d8", // Match border color to the background color
       });
     }
   }

--- a/src/app/timetable/components/calender/calender.js
+++ b/src/app/timetable/components/calender/calender.js
@@ -50,10 +50,10 @@ export default function calendar() {
         initialView="timeGridWeek"
         editable={true}
         selectable={true}
-        height={650}
         events={events}
         select={handleDateSelect}
         eventClick={handleEventClick}
+        slotLaneClassNames="custom-slot-class"
       />
 
       {modalIsOpen && (

--- a/src/app/timetable/components/calender/calender.js
+++ b/src/app/timetable/components/calender/calender.js
@@ -1,5 +1,6 @@
 "use client";
 
+import React, { useState } from "react";
 import FullCalendar from "@fullcalendar/react";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import interactionPlugin from "@fullcalendar/interaction";
@@ -7,38 +8,33 @@ import { createEventId } from "./event-utils";
 import styles from "./style.module.scss";
 
 export default function Calendar() {
-  return (
-    <div className={styles.calender_main}>
-      <FullCalendar
-        plugins={[timeGridPlugin, interactionPlugin]}
-        initialView="timeGridWeek"
-        editable={true}
-        selectable={true}
-        height={650}
-        select={handleDateSelect}
-        eventContent={renderEventContent}
-        eventClick={handleEventClick}
-      />
-    </div>
-  );
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+  const [selectedInfo, setSelectedInfo] = useState(null);
+  const [title, setTitle] = useState("");
+  const [color, setColor] = useState("#3788d8"); // Default color
 
   function handleDateSelect(selectInfo) {
-    let title = prompt("Please enter a new title for your event");
-    let color = prompt("Please enter a color for your event (e.g., #ff0000)");
-    let calendarApi = selectInfo.view.calendar;
+    setSelectedInfo(selectInfo);
+    setModalIsOpen(true);
+  }
 
-    calendarApi.unselect(); // clear date selection
+  function handleEventCreation() {
+    if (title && selectedInfo) {
+      let calendarApi = selectedInfo.view.calendar;
 
-    if (title) {
       calendarApi.addEvent({
         id: createEventId(),
         title,
-        start: selectInfo.startStr,
-        end: selectInfo.endStr,
-        allDay: selectInfo.allDay,
-        backgroundColor: color || "#3788d8", // Default color if none is provided
-        borderColor: color || "#3788d8", // Match border color to the background color
+        start: selectedInfo.startStr,
+        end: selectedInfo.endStr,
+        allDay: selectedInfo.allDay,
+        backgroundColor: color,
+        borderColor: color,
       });
+
+      setModalIsOpen(false);
+      setTitle("");
+      setColor("#3788d8"); // Reset to default
     }
   }
 
@@ -60,4 +56,40 @@ export default function Calendar() {
       </>
     );
   }
+
+  return (
+    <div className={styles.calendar_main}>
+      <FullCalendar
+        plugins={[timeGridPlugin, interactionPlugin]}
+        initialView="timeGridWeek"
+        editable={true}
+        selectable={true}
+        height={650}
+        select={handleDateSelect}
+        eventContent={renderEventContent}
+        eventClick={handleEventClick}
+      />
+
+      {modalIsOpen && (
+        <div className={styles.modalOverlay}>
+          <div className={styles.modalContent}>
+            <h2>Create New Event</h2>
+            <input
+              type="text"
+              placeholder="Event Title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+            <input
+              type="color"
+              value={color}
+              onChange={(e) => setColor(e.target.value)}
+            />
+            <button onClick={handleEventCreation}>Create Event</button>
+            <button onClick={() => setModalIsOpen(false)}>Cancel</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/app/timetable/components/calender/calender.js
+++ b/src/app/timetable/components/calender/calender.js
@@ -58,7 +58,11 @@ export default function Calendar() {
         events={events} // Passing the list of events to the calendar.
         select={handleDateSelect} // Event handler for date selection.
         eventClick={handleEventClick} // Event handler for event clicks.
-        slotLaneClassNames="custom-slot-class" // Adding a custom class for further styling.
+        slotLabelFormat={{
+          hour: "numeric",
+          minute: "2-digit",
+          omitZeroMinute: false,
+        }} // Format for time slot labels.
       />
 
       {/* Render the event creation modal if it is open */}

--- a/src/app/timetable/components/calender/calender.js
+++ b/src/app/timetable/components/calender/calender.js
@@ -8,7 +8,7 @@ import styles from "./style.module.scss";
 import EventModal from "./eventModal";
 import DeleteModal from "./deleteModal"; // New component for delete confirmation
 
-export default function calendar() {
+export default function Calendar() {
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [deleteModalIsOpen, setDeleteModalIsOpen] = useState(false);
   const [events, setEvents] = useState([]);

--- a/src/app/timetable/components/calender/calender.js
+++ b/src/app/timetable/components/calender/calender.js
@@ -92,11 +92,12 @@ export default function Calendar() {
             {/* Input for event title */}
             <input
               type="text"
-              placeholder="Event Title"
+              placeholder="Enter event title"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
             />
             {/* Input for event color */}
+            <h3>Pick a colour</h3>
             <input
               type="color"
               value={color}

--- a/src/app/timetable/components/calender/deleteModal.js
+++ b/src/app/timetable/components/calender/deleteModal.js
@@ -1,0 +1,36 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styles from "./style.module.scss";
+
+export default function deleteModal({
+  isOpen,
+  setIsOpen,
+  handleDelete,
+  eventTitle,
+}) {
+  return (
+    isOpen && (
+      <div className={styles.modalOverlay}>
+        <div className={styles.modalContent}>
+          <h2>Delete Event</h2>
+          <p>Are you sure you want to delete the event '{eventTitle}'?</p>
+          <button onClick={handleDelete}>Delete</button>
+          <button onClick={() => setIsOpen(false)}>Cancel</button>
+        </div>
+      </div>
+    )
+  );
+}
+
+// Define PropTypes for DeleteModal
+deleteModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  setIsOpen: PropTypes.func.isRequired,
+  handleDelete: PropTypes.func.isRequired,
+  eventTitle: PropTypes.string,
+};
+
+// Define default props if necessary
+deleteModal.defaultProps = {
+  eventTitle: "the event",
+};

--- a/src/app/timetable/components/calender/deleteModal.js
+++ b/src/app/timetable/components/calender/deleteModal.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styles from "./style.module.scss";
 
-export default function deleteModal({
+export default function DeleteModal({
   isOpen,
   setIsOpen,
   handleDelete,
@@ -23,7 +23,7 @@ export default function deleteModal({
 }
 
 // Define PropTypes for DeleteModal
-deleteModal.propTypes = {
+DeleteModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   setIsOpen: PropTypes.func.isRequired,
   handleDelete: PropTypes.func.isRequired,
@@ -31,6 +31,6 @@ deleteModal.propTypes = {
 };
 
 // Define default props if necessary
-deleteModal.defaultProps = {
+DeleteModal.defaultProps = {
   eventTitle: "the event",
 };

--- a/src/app/timetable/components/calender/deleteModal.js
+++ b/src/app/timetable/components/calender/deleteModal.js
@@ -1,20 +1,24 @@
 import React from "react";
 import PropTypes from "prop-types";
-import styles from "./style.module.scss";
+import styles from "./style.module.scss"; // Import custom styles
 
+// Component for the delete confirmation modal
 export default function DeleteModal({
-  isOpen,
-  setIsOpen,
-  handleDelete,
-  eventTitle,
+  isOpen, // Boolean to control the modal visibility
+  setIsOpen, // Function to toggle the modal visibility
+  handleDelete, // Function to handle the event deletion
+  eventTitle, // Title of the event to be deleted
 }) {
   return (
-    isOpen && (
+    isOpen && ( // Render the modal only if `isOpen` is true
       <div className={styles.modalOverlay}>
         <div className={styles.modalContent}>
           <h2>Delete Event</h2>
+          {/* Confirmation message with the event title */}
           <p>Are you sure you want to delete the event '{eventTitle}'?</p>
+          {/* Button to confirm deletion */}
           <button onClick={handleDelete}>Delete</button>
+          {/* Button to cancel and close the modal */}
           <button onClick={() => setIsOpen(false)}>Cancel</button>
         </div>
       </div>
@@ -22,15 +26,15 @@ export default function DeleteModal({
   );
 }
 
-// Define PropTypes for DeleteModal
+// Define PropTypes for DeleteModal to enforce the types of props passed
 DeleteModal.propTypes = {
-  isOpen: PropTypes.bool.isRequired,
-  setIsOpen: PropTypes.func.isRequired,
-  handleDelete: PropTypes.func.isRequired,
-  eventTitle: PropTypes.string,
+  isOpen: PropTypes.bool.isRequired, // Boolean to indicate if the modal should be visible
+  setIsOpen: PropTypes.func.isRequired, // Function to toggle the modal visibility
+  handleDelete: PropTypes.func.isRequired, // Function to handle the deletion of the event
+  eventTitle: PropTypes.string, // String for the title of the event to be deleted
 };
 
 // Define default props if necessary
 DeleteModal.defaultProps = {
-  eventTitle: "the event",
+  eventTitle: "the event", // Default event title if not provided
 };

--- a/src/app/timetable/components/calender/eventModal.js
+++ b/src/app/timetable/components/calender/eventModal.js
@@ -1,0 +1,78 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types"; // Import PropTypes
+import styles from "./style.module.scss";
+import { createEventId } from "./event-utils";
+
+export default function EventModal({
+  isOpen,
+  setIsOpen,
+  selectedInfo,
+  setEvents,
+}) {
+  const [title, setTitle] = useState("");
+  const [color, setColor] = useState("#3788d8");
+
+  const handleEventCreation = async () => {
+    if (title && selectedInfo) {
+      const newEvent = {
+        id: createEventId(),
+        title,
+        start: selectedInfo.startStr,
+        end: selectedInfo.endStr,
+        allDay: selectedInfo.allDay,
+        backgroundColor: color,
+        borderColor: color,
+      };
+
+      // Add to local state
+      setEvents((prevEvents) => {
+        if (Array.isArray(prevEvents)) {
+          return [...prevEvents, newEvent];
+        } else {
+          console.error("prevEvents is not an array", prevEvents);
+          return [newEvent]; // Fallback to just the new event
+        }
+      });
+
+      // Close modal
+      setIsOpen(false);
+      setTitle("");
+      setColor("#3788d8");
+    }
+  };
+
+  return (
+    <div className={styles.modalOverlay}>
+      <div className={styles.modalContent}>
+        <h2>Create New Event</h2>
+        <input
+          type="text"
+          placeholder="Enter event title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <h3>Pick a color</h3>
+        <input
+          type="color"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+        />
+        <button onClick={handleEventCreation}>Create Event</button>
+        <button onClick={() => setIsOpen(false)}>Cancel</button>
+      </div>
+    </div>
+  );
+}
+
+// Define PropTypes for EventModal
+EventModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  setIsOpen: PropTypes.func.isRequired,
+  selectedInfo: PropTypes.object,
+  setEvents: PropTypes.func.isRequired,
+};
+
+// Define default props if necessary
+EventModal.defaultProps = {
+  selectedInfo: null,
+};

--- a/src/app/timetable/components/calender/eventModal.js
+++ b/src/app/timetable/components/calender/eventModal.js
@@ -1,35 +1,38 @@
 import React, { useState } from "react";
-import PropTypes from "prop-types"; // Import PropTypes
-import styles from "./style.module.scss";
-import { createEventId } from "./event-utils";
+import PropTypes from "prop-types"; // Import PropTypes for type checking
+import styles from "./style.module.scss"; // Import custom styles
+import { createEventId } from "./event-utils"; // Utility function to create unique event IDs
 
 export default function EventModal({ setIsOpen, selectedInfo, setEvents }) {
+  // State to manage the event title and color
   const [title, setTitle] = useState("");
-  const [color, setColor] = useState("#3788d8");
+  const [color, setColor] = useState("#3788d8"); // Default color set to blue
 
+  // Function to handle the creation of a new event
   const handleEventCreation = async () => {
     if (title && selectedInfo) {
+      // Create a new event object with the entered details
       const newEvent = {
-        id: createEventId(),
+        id: createEventId(), // Generate a unique ID for the event
         title,
-        start: selectedInfo.startStr,
-        end: selectedInfo.endStr,
-        allDay: selectedInfo.allDay,
-        backgroundColor: color,
-        borderColor: color,
+        start: selectedInfo.startStr, // Start time of the event
+        end: selectedInfo.endStr, // End time of the event
+        allDay: selectedInfo.allDay, // Boolean indicating if it's an all-day event
+        backgroundColor: color, // Set the background color of the event
+        borderColor: color, // Set the border color of the event
       };
 
-      // Add to local state
+      // Add the new event to the list of events in the parent component's state
       setEvents((prevEvents) => {
         if (Array.isArray(prevEvents)) {
-          return [...prevEvents, newEvent];
+          return [...prevEvents, newEvent]; // Add new event to the array of existing events
         } else {
           console.error("prevEvents is not an array", prevEvents);
-          return [newEvent]; // Fallback to just the new event
+          return [newEvent]; // Fallback: initialize with just the new event
         }
       });
 
-      // Close modal
+      // Close the modal and reset the title and color states
       setIsOpen(false);
       setTitle("");
       setColor("#3788d8");
@@ -40,6 +43,7 @@ export default function EventModal({ setIsOpen, selectedInfo, setEvents }) {
     <div className={styles.modalOverlay}>
       <div className={styles.modalContent}>
         <h2>Create New Event</h2>
+        {/* Input field for entering the event title */}
         <input
           type="text"
           placeholder="Enter event title"
@@ -47,26 +51,29 @@ export default function EventModal({ setIsOpen, selectedInfo, setEvents }) {
           onChange={(e) => setTitle(e.target.value)}
         />
         <h2>Pick a color</h2>
+        {/* Color picker for selecting the event color */}
         <input
           type="color"
           value={color}
           onChange={(e) => setColor(e.target.value)}
         />
+        {/* Button to create the event */}
         <button onClick={handleEventCreation}>Create Event</button>
+        {/* Button to cancel and close the modal */}
         <button onClick={() => setIsOpen(false)}>Cancel</button>
       </div>
     </div>
   );
 }
 
-// Define PropTypes for EventModal
+// Define PropTypes for EventModal to enforce the types of props passed
 EventModal.propTypes = {
-  setIsOpen: PropTypes.func.isRequired,
-  selectedInfo: PropTypes.object,
-  setEvents: PropTypes.func.isRequired,
+  setIsOpen: PropTypes.func.isRequired, // Function to control the visibility of the modal
+  selectedInfo: PropTypes.object, // Object containing selected date/time information
+  setEvents: PropTypes.func.isRequired, // Function to update the events state in the parent component
 };
 
 // Define default props if necessary
 EventModal.defaultProps = {
-  selectedInfo: null,
+  selectedInfo: null, // Default value for selectedInfo if not provided
 };

--- a/src/app/timetable/components/calender/eventModal.js
+++ b/src/app/timetable/components/calender/eventModal.js
@@ -61,7 +61,6 @@ export default function EventModal({ setIsOpen, selectedInfo, setEvents }) {
 
 // Define PropTypes for EventModal
 EventModal.propTypes = {
-  isOpen: PropTypes.bool.isRequired,
   setIsOpen: PropTypes.func.isRequired,
   selectedInfo: PropTypes.object,
   setEvents: PropTypes.func.isRequired,

--- a/src/app/timetable/components/calender/eventModal.js
+++ b/src/app/timetable/components/calender/eventModal.js
@@ -50,7 +50,7 @@ export default function EventModal({ setIsOpen, selectedInfo, setEvents }) {
           value={title}
           onChange={(e) => setTitle(e.target.value)}
         />
-        <h2>Pick a color</h2>
+        <h2>Pick a colour</h2>
         {/* Color picker for selecting the event color */}
         <input
           type="color"

--- a/src/app/timetable/components/calender/eventModal.js
+++ b/src/app/timetable/components/calender/eventModal.js
@@ -3,12 +3,7 @@ import PropTypes from "prop-types"; // Import PropTypes
 import styles from "./style.module.scss";
 import { createEventId } from "./event-utils";
 
-export default function EventModal({
-  isOpen,
-  setIsOpen,
-  selectedInfo,
-  setEvents,
-}) {
+export default function EventModal({ setIsOpen, selectedInfo, setEvents }) {
   const [title, setTitle] = useState("");
   const [color, setColor] = useState("#3788d8");
 
@@ -51,7 +46,7 @@ export default function EventModal({
           value={title}
           onChange={(e) => setTitle(e.target.value)}
         />
-        <h3>Pick a color</h3>
+        <h2>Pick a color</h2>
         <input
           type="color"
           value={color}

--- a/src/app/timetable/components/calender/style.module.scss
+++ b/src/app/timetable/components/calender/style.module.scss
@@ -1,0 +1,3 @@
+.calender_main {
+  padding: 5em;
+}

--- a/src/app/timetable/components/calender/style.module.scss
+++ b/src/app/timetable/components/calender/style.module.scss
@@ -1,3 +1,79 @@
-.calender_main {
+/* style.module.scss */
+.calendar_main {
   padding: 5em;
+  background-color: #f7f7f7;
+  min-height: 100vh;
+}
+
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5); /* Semi-transparent background */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000; /* Ensure it's on top of other elements */
+}
+
+.modalContent {
+  background-color: #fff;
+  padding: 2em;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  width: 100%;
+  max-width: 500px;
+  text-align: center;
+}
+
+.modalContent h2 {
+  margin-bottom: 1em;
+  font-size: 1.5em;
+  color: #333;
+}
+
+.modalContent input[type="text"] {
+  width: 100%;
+  padding: 0.5em;
+  margin-bottom: 1em;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1em;
+}
+
+.modalContent input[type="color"] {
+  width: 518px;
+  height: 100px;
+  padding: 0.5em;
+  margin-bottom: 1em;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.modalContent button {
+  padding: 0.75em 1.5em;
+  margin: 0.5em;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1em;
+  color: #fff;
+  background-color: #3788d8;
+  transition: background-color 0.3s ease;
+}
+
+.modalContent button:hover {
+  background-color: #2b6ba8;
+}
+
+.modalContent button:last-child {
+  background-color: #ccc;
+  color: #333;
+}
+
+.modalContent button:last-child:hover {
+  background-color: #999;
 }

--- a/src/app/timetable/components/calender/style.module.scss
+++ b/src/app/timetable/components/calender/style.module.scss
@@ -1,8 +1,9 @@
 /* style.module.scss */
 .calendar_main {
-  padding: 5em;
-  background-color: #f7f7f7;
-  min-height: 100vh;
+  padding-left: 25%;
+  padding-right: 25%;
+  height: auto;
+  z-index: 1;
 }
 
 .modalOverlay {
@@ -19,7 +20,7 @@
 }
 
 .modalContent {
-  background-color: #fff;
+  background-color: #9bc4bc;
   padding: 2em;
   border-radius: 8px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
@@ -31,7 +32,6 @@
 .modalContent h2 {
   margin-bottom: 1em;
   font-size: 1.5em;
-  color: #333;
 }
 
 .modalContent input[type="text"] {

--- a/src/app/timetable/components/calender/style.module.scss
+++ b/src/app/timetable/components/calender/style.module.scss
@@ -1,4 +1,4 @@
-/* style.module.scss */
+/* Main calendar container with padding and positioning */
 .calendar_main {
   padding-left: 25%;
   padding-right: 25%;
@@ -6,6 +6,7 @@
   z-index: 1;
 }
 
+/* Overlay for modal, covering the entire screen with a semi-transparent background */
 .modalOverlay {
   position: fixed;
   top: 0;
@@ -19,6 +20,7 @@
   z-index: 1000; /* Ensure it's on top of other elements */
 }
 
+/* Content box for the modal, centered on the screen */
 .modalContent {
   background-color: #9bc4bc;
   padding: 2em;
@@ -29,11 +31,13 @@
   text-align: center;
 }
 
+/* Header style within the modal content */
 .modalContent h2 {
   margin-bottom: 1em;
   font-size: 1.5em;
 }
 
+/* Style for the text input within the modal */
 .modalContent input[type="text"] {
   width: 100%;
   padding: 0.5em;
@@ -43,6 +47,7 @@
   font-size: 1em;
 }
 
+/* Style for the color picker input within the modal */
 .modalContent input[type="color"] {
   width: 518px;
   height: 100px;
@@ -53,6 +58,7 @@
   cursor: pointer;
 }
 
+/* General button styles within the modal */
 .modalContent button {
   padding: 0.75em 1.5em;
   margin: 0.5em;
@@ -65,15 +71,18 @@
   transition: background-color 0.3s ease;
 }
 
+/* Hover state for the primary button */
 .modalContent button:hover {
   background-color: #2b6ba8;
 }
 
+/* Style for the cancel button within the modal */
 .modalContent button:last-child {
   background-color: #ccc;
   color: #333;
 }
 
+/* Hover state for the cancel button */
 .modalContent button:last-child:hover {
   background-color: #999;
 }


### PR DESCRIPTION
# Updated styling and customisability of calendar events.

## Related Issue
Closes #41 

## Description
- Event creation modal update (UI and colour customisation).
- Event deletion modal update (UI).
- Resized calendar to fit better (Currently not within constraints defined on Figma as it may be too small).
- Changed calendar time format.
- Added comments for easier understanding of components (lots of use states can be confusing to new readers).
- Separated modals into components for modularity.
- Refactored event storage to prepare for persistence to database.

## Testing
### Event creation modal
- When a time slot or range is selected (by clicking or dragging across time slots), the event creation modal appears and dims the rest of the screen.
- Colour of the event can be picked by clicking on the colour rectangle and using the colour panel.
- Creation of event can only occur when title has been filled out and colour is chosen (default colour is already chosen).
- Clicking the create event button creates an event if input requirements are met and closes the modal. Clicking cancel closes the modal.

### Event deletion modal
- When an existing event is clicked on, the event deletion modal appears and dims the rest of the screen.
- Clicking the delete button removes the selected event and closes the modal. Clicking cancel closes the modal.

## Images 
Event creation modal:
![image](https://github.com/user-attachments/assets/b95084c4-b197-4474-aa6c-c018f07a1010)

Event deletion modal:
![image](https://github.com/user-attachments/assets/131842ff-319e-4e2a-8e45-8f8414343d4a)


## Additional Context
- The events currently do not persist to the database. This will be added as another issue.