### PR TITLE
Fix PropTypes error from missing import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "mongoose": "^8.5.2",
         "next": "14.2.5",
         "next-auth": "^5.0.0-beta.20",
+        "prop-types": "^15.8.1",
         "react": "^18",
         "react-blockies": "^1.4.1",
         "react-dom": "^18",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "mongoose": "^8.5.2",
     "next": "14.2.5",
     "next-auth": "^5.0.0-beta.20",
+    "prop-types": "^15.8.1",
     "react": "^18",
     "react-blockies": "^1.4.1",
     "react-dom": "^18",

--- a/src/components/auth/avatar.jsx
+++ b/src/components/auth/avatar.jsx
@@ -1,5 +1,6 @@
 "use client"
 
+import PropTypes from "prop-types"
 import Blockies from "react-blockies"
 import styles from "./auth.module.scss"
 


### PR DESCRIPTION
# Fix PropTypes error from missing import

## Related Issue
Closes: #46 

## Description
This pull request adds the missing PropTypes import statement to the Avatar component, which was previously causing a console warning.

Added: import PropTypes from 'prop-types'; to the top of the Avatar.js file.

## Testing
After adding the missing import, the component was tested by rendering it with various valid and invalid props to ensure that the PropTypes validation is now working as expected.

## Images 
N/A

## Additional Context
This issue caused by fixing a SonarCloud issue which recommended adding PropTypes. However, the React version we were using did not have a PropTypes reference by default, requiring an extra import.