### PR TITLE
Grade Calculator: Fix numerical values not updating after deleting assignments

### DIFF
--- a/src/app/calculator/page.js
+++ b/src/app/calculator/page.js
@@ -9,7 +9,8 @@ export default function CalculatorPage() {
   let array = new Uint32Array(1);
 
   const [isInputNameEmpty, setIsInputNameEmpty] = useState(true);
-  const [courses, setCourses] = useState([]); // courses array stores course objects (not course components)
+  // 'courses' array stores course objects (not course components).  Each course object contains the fields: 'id', 'courseName', and 'gradePoint'.
+  const [courses, setCourses] = useState([]);
   const [courseName, setCourseName] = useState();
   const [gpa, setGpa] = useState("X");
 
@@ -28,11 +29,11 @@ export default function CalculatorPage() {
   };
 
   /**
-   * Updates a course in 'courses' gradepoint field. Is finally called in the
-   * useEffect hook of course.jsx.
-   * 
-   * @param {*} id 
-   * @param {*} gradePoint 
+   * Updates the 'gradePoint' field courses in the 'courses' array. This function is passed into 'CourseList' components and
+   * is ultimately called in the useEffect hook of 'Course' components.
+   *
+   * @param {*} id
+   * @param {*} gradePoint
    */
   const handleAverageUpdate = (id, gradePoint) => {
     const updatedCourses = courses.map((course) =>
@@ -41,6 +42,10 @@ export default function CalculatorPage() {
     setCourses(updatedCourses);
   };
 
+  /**
+   * Listens for changes made to the 'courses' aray so that 'gpa' can be set accordingly.
+   *
+   */
   useEffect(() => {
     let newGpa = 0;
     // Since this hook is called whenever the 'courses' array changes, some courses in the array may not have a

--- a/src/components/calculator/course.jsx
+++ b/src/components/calculator/course.jsx
@@ -14,7 +14,7 @@ import Assignment from "./assignment";
  * - `totalAchieved` (Number): The total percentage achieved for the course.
  * - `averageAchieved` (Number): The average percentage achieved for the course.
  * - `courseGrade` (String): The grade of the course, default is "NA".
- * - `assignments` (Array): Array of assignment objects associated with the course.
+ * - `assignments` (Array): Array of assignment objects associated with the course. Each assignment contains an 'id' field.
  * @param {*} props 
  * @returns 
  */
@@ -34,7 +34,13 @@ export default function Course(props) {
   };
 
   const handleAssignmentDelete = (id) => {
-    setAssignments(assignments.filter((assignment) => assignment.id !== id));
+    const updatedAssignments = assignments.filter(
+      (assignment) => assignment.id !== id
+    );
+    setAssignments(updatedAssignments);
+    calculateTotalPercent(updatedAssignments);
+    calculateAveragePercent(updatedAssignments);
+    
   };
 
   const handleCourseClick = () => {


### PR DESCRIPTION
# Grade Calculator: Fix numerical values not updating after deleting assignments

## Related Issue
Closes #61 

## Description
This pull request recalculates the `GPA` of the student and `Total %` and `Average %` of a course after an assignment is is deleted and displays the values accordingly.

## Testing
- `GPA`, `Total %` and Average % change to correct values after deleting assignment This behaviour should work with multiple assignments within a course and with multiple courses.

## Additional Context
This issue was caused by not calling the calculation methods to recalculate `GPA`, `Total %` and `Average %`  upon assignment deletion. Therefore no additional testing of calculation methods themselves was required.