### PR TITLE
Added Mobile friendly login/register page

### DIFF
--- a/src/app/auth/auth.css
+++ b/src/app/auth/auth.css
@@ -31,6 +31,18 @@
   width: 300px;
 }
 
+@media (max-width: 450px) {
+  body {
+    margin: 0 7.5% 0 7.5%;
+  }
+  .auth_form {
+    width: 100%;
+  }
+  .auth__form input {
+    width: 90%;
+  }
+}
+
 .auth__form input::placeholder {
   color: #cbd5e1;
 }


### PR DESCRIPTION
# Mobile friendly login/register page
Closes #94 

## Description
This makes the login and register page visible to mobile users. 

![image](https://github.com/user-attachments/assets/f374f736-1fe3-4dc5-af06-5f186d6ba57b)
![image](https://github.com/user-attachments/assets/dbdbfc7c-2461-4abf-92b4-159890cb6aa1)

The hamburger button is made smaller in this PR - #91 
 ## Testing
Ensure that all is still functional and UI is easy to read. Should work down to a screen width of 280px (size of Galaxy Fold)